### PR TITLE
[Fix & Advice] 对ver 0.2.7提出我本人建议的两点修改

### DIFF
--- a/src/main/tray.js
+++ b/src/main/tray.js
@@ -1,10 +1,10 @@
-import { Menu, Tray, nativeImage } from 'electron'
+import { Menu, nativeImage, Tray } from 'electron'
 import { appConfig$ } from './data'
 import * as handler from './tray-handler'
 import { checkUpdate } from './updater'
 import { groupConfigs } from '../shared/utils'
-import { isMac, isWin, isOldMacVersion } from '../shared/env'
-import { disabledTray, enabledTray, enabledHighlightTray, pacTray, pacHighlightTray, globalTray, globalHighlightTray } from '../shared/icon'
+import { isMac, isOldMacVersion, isWin } from '../shared/env'
+import { disabledTray, enabledHighlightTray, enabledTray, globalHighlightTray, globalTray, pacHighlightTray, pacTray } from '../shared/icon'
 
 let tray
 
@@ -55,7 +55,10 @@ function generateConfigSubmenus (configs, selectedIndex) {
 function generateMenus (appConfig) {
   const base = [
     { label: '主界面', click: handler.showManagePanel },
-    { label: '开启应用', type: 'checkbox', checked: appConfig.enable, click: handler.toggleEnable },
+    { label: '开启应用', type: 'checkbox', checked: appConfig.enable, click: () => {
+      handler.toggleEnable()
+      handler.toggleProxy(appConfig.sysProxyMode)
+    } },
     { label: 'PAC', submenu: [
       { label: '更新PAC', click: handler.updatePac }
     ] },

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -1,4 +1,5 @@
-import { isLinux, isMac } from './env'
+import { isLinux } from './env'
+
 const defaultConfig = {
   // 配置集合
   configs: [],
@@ -36,7 +37,7 @@ const defaultConfig = {
   // 窗口快捷键
   windowShortcuts: {
     toggleMenu: {
-      key: isLinux ? `${isMac ? 'Command' : 'Ctrl'}+Shift+B` : '',
+      key: isLinux ? 'Ctrl+Shift+B' : '',
       enable: isLinux
     }
   },


### PR DESCRIPTION
## [Advice] 窗口快捷键的绑定不需要判断isMac

### 原因

应用内快捷键仅Linux可用，并且因为`isLinux`、`isMac`、`isWin`都是基于`os.platform()`来判断的，当`isLinux`成立（为`true`）时，`窗口快捷键`绑定中的`isMac`始终不成立，只会绑定为`Ctrl`。

### 建议

在此我建议将`isMac`判断移除，仅在Linux系统下仅绑定`Ctrl+Shift+B`。

## [Fix] 开启应用时需要同时触发toggleProxy

### 原因

我在`开启应用`前已经选中了`系统代理模式`中的某一项，开启应用后，系统的代理设置没有更新到正确的代理模式配置中。这一点虽然在FAQ中已经有描述解释了“为什么我打开了应用但是没有代理成功”，但每次重新打开electron-ssr并且开启应用时，都需要再次手动切换`系统代理模式`，我认为这个体验稍微有点不太好。

### 分析

查看过`开启应用`和`系统代理模式`的click事件绑定后，我发现`开启应用`只绑定了`toggleEnable`函数。根据日志分析，在开启应用时，`toggleEnable`仅仅更新了`currentConfig.enable`的状态，而没有执行变更代理设置的脚本。

`系统代理模式`的click事件绑定的`toggleProxy`函数，会先执行`startProxy`，更新代理设置到我选中的代理模式，再更新应用配置。但当应用还未开启，`currentConfig.enable = false`时，代理设置会在`startProxy`执行完毕后，被重制到没有设置系统代理的状态。我通过日志分析出，`currentConfig.enable = false`时，`toggleProxy`函数里做了`setProxyToXXX() -> setProxyToNone()`的调用处理。（在此恕我没有对EventBus进行深入挖掘，仅得出这样浅显的分析结论）

### 修复

我在`开启应用`的click事件增加绑定了`toggleProxy`函数，参数为`appConfig.sysProxyMode`，这样在开启应用的时候，系统代理设置就会自动被设置到正确的模式，关闭时也会回归到不走代理的状态。

特别指出，`currentConfig.enable = true`时，无论如何切换系统代理模式，代理设置都会被正确更新，所以这个修复不会影响开启应用时的模式切换。